### PR TITLE
Prepare: add main to Pages workflow triggers

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -4,7 +4,7 @@ name: Deploy Hugo site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: ["master","main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This prepares the repository for renaming the default branch from master to main.

Changes:
- Update [hugo.yml](.github/workflows/hugo.yml) push trigger branches to ["master","main"] so GitHub Pages deploys continue immediately after the rename.

Plan:
1. Merge this PR to master.
2. Rename master -> main via GitHub API (creates redirects and retargets PRs).
3. Verify default branch and protections.
4. Follow-up PR will switch triggers to only ["main"] and update [README.md](README.md) references.

No functional runtime changes; CI-only.

## Summary by Sourcery

CI:
- Include the 'main' branch alongside 'master' in the Hugo Pages GitHub Actions workflow push triggers