### PR TITLE
Cleanup after default branch rename to main

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -4,7 +4,7 @@ name: Deploy Hugo site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master","main"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,7 +3,7 @@ name: Content Quality
 on:
   pull_request:
   push:
-    branches: [ "main", "master" ]
+    branches: [ "main" ]
 
 jobs:
   lint-markdown:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Similar structure in `content/projects/`
 
 ## 🚢 Deployment
 
-The site automatically deploys to GitHub Pages when changes are pushed to the `main` or `master` branch.
+The site automatically deploys to GitHub Pages when changes are pushed to the `main` branch.
 
 ### Manual Deployment
 


### PR DESCRIPTION
This PR finalizes the default-branch rename to main.

Summary of completed rename steps:
- Default branch is now main; GitHub redirects from master are active
- Protections are applied to main (no required checks per previous settings)
- Open PRs targeting master retargeted to main (notably PR #7)
- Safety backups preserved: backup/master-20250825 and pre-rename/master-20250825

Cleanup changes:
- Update [hugo.yml](.github/workflows/hugo.yml) triggers to ["main"] only
- Update [quality.yml](.github/workflows/quality.yml) triggers to ["main"] only
- Update [README.md](README.md) to reference main only for GitHub Pages deploy

References:
- Pre-rename snapshot issue: https://github.com/amanthanvi/personal-website/issues/9

After merge:
- I will post a checklist update to Issue #9 and confirm a Pages deployment runs from main

No functional site changes; CI-only and docs.

## Summary by Sourcery

Finalize the default branch rename to 'main' by cleaning up CI workflows and documentation

CI:
- Update Hugo and quality GitHub Actions workflows to trigger only on the main branch

Documentation:
- Update README deployment instructions to reference only the main branch