### PR TITLE
fix: point robots.txt at the sitemap the build actually emits

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://amanthanvi.com/sitemap.xml
+Sitemap: https://amanthanvi.com/sitemap-index.xml


### PR DESCRIPTION
One-line fix for a broken sitemap reference that is live on `main` today.

## User-facing impact

`public/robots.txt` advertises a sitemap URL that nothing generates, so any crawler that reads robots.txt and follows the `Sitemap:` line gets a **404 and discovers no sitemap**. Search engines fall back to plain link discovery.

## Cause

The single-column redesign (#42) replaced the hand-written `src/pages/sitemap.xml.ts` with the `@astrojs/sitemap` integration:

```js
integrations: [mdx(), sitemap()],
```

That integration emits `sitemap-index.xml` (plus `sitemap-0.xml`) rather than `sitemap.xml`, but `robots.txt` was not updated alongside it:

```
Sitemap: https://amanthanvi.com/sitemap.xml
```

`src/pages/sitemap.xml.ts` no longer exists on `main`, so no route produces that path.

## The change

```diff
-Sitemap: https://amanthanvi.com/sitemap.xml
+Sitemap: https://amanthanvi.com/sitemap-index.xml
```

Pointing at the index (rather than `sitemap-0.xml`) is deliberate — it stays correct if the site later grows past one sitemap shard.

## Verification

Confirmed against a real build of this branch, not inferred:

```
$ ls dist | grep -i sitemap
sitemap-0.xml
sitemap-index.xml          # no sitemap.xml is produced

$ cat dist/robots.txt
User-agent: *
Allow: /

Sitemap: https://amanthanvi.com/sitemap-index.xml
```

- `npm run build` — 3 pages, `[@astrojs/sitemap] sitemap-index.xml created at dist`
- `npm run check` — 0 errors / 0 warnings / 0 hints
- `npm audit` — 0 vulnerabilities

No screenshots: this is a crawler-facing text file with no visual change.

## Scope

Content of `public/robots.txt` only. This is pre-existing on `main` (verified at `b1de618`) rather than a regression from #41; it surfaced while verifying that PR's fixes against the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9QyvBZFS2WFwQCALtBxcC

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9QyvBZFS2WFwQCALtBxcC)_

## Summary by Sourcery

Bug Fixes:
- Correct the sitemap URL in robots.txt to point to the generated sitemap-index.xml instead of a non-existent sitemap.xml.